### PR TITLE
Modify systemd service file dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -216,8 +216,6 @@ setup_systemd_service() {
     cat <<EOF > "${SERVICE_FILE}"
 [Unit]
 Description=saycharlie SVX Dashboard
-## After=network.target svxlink.service
-## Requires=svxlink.service
 After=network.target
 Wants=svxlink.service
 After=svxlink.service

--- a/install.sh
+++ b/install.sh
@@ -220,7 +220,7 @@ Description=saycharlie SVX Dashboard
 ## Requires=svxlink.service
 After=network.target
 Wants=svxlink.service
-After=svxlink.servicee
+After=svxlink.service
 
 [Service]
 User=${SVXLINK_USER}

--- a/install.sh
+++ b/install.sh
@@ -216,8 +216,11 @@ setup_systemd_service() {
     cat <<EOF > "${SERVICE_FILE}"
 [Unit]
 Description=saycharlie SVX Dashboard
-After=network.target svxlink.service
-Requires=svxlink.service
+## After=network.target svxlink.service
+## Requires=svxlink.service
+After=network.target
+Wants=svxlink.service
+After=svxlink.servicee
 
 [Service]
 User=${SVXLINK_USER}


### PR DESCRIPTION
 you don’t make the dashboard dependent on the radio service. The whole point is that it should stay reachable precisely when SVXLink is acting up.